### PR TITLE
Added screenshot for Freshdesk documentation

### DIFF
--- a/Freshdesk/v2/README.md
+++ b/Freshdesk/v2/README.md
@@ -5,11 +5,7 @@ This repository contains sample apps demonstrating the various features availabl
 
 This app shows the Freshdesk logo and the name of the ticket requester.
 
-<<<<<<< HEAD
 ![Screenshot 2019-10-05 at 4 36 19 PM](https://user-images.githubusercontent.com/6701828/66254038-635e2f80-e78e-11e9-89b6-b69e2d7d3378.png)
-=======
-![Screenshot 2019-10-05 at 11 29 52 AM](https://user-images.githubusercontent.com/6701828/66250692-9d660c00-e763-11e9-8c04-fe360e731c4f.png)
->>>>>>> 107b0f03dbdcc089ac44cc9c93b8c5c1602c291b
 
 
 This app demonstrates the following features

--- a/Freshdesk/v2/README.md
+++ b/Freshdesk/v2/README.md
@@ -5,6 +5,9 @@ This repository contains sample apps demonstrating the various features availabl
 
 This app shows the Freshdesk logo and the name of the ticket requester.
 
+![Screenshot 2019-10-05 at 4 36 19 PM](https://user-images.githubusercontent.com/6701828/66254038-635e2f80-e78e-11e9-89b6-b69e2d7d3378.png)
+
+
 This app demonstrates the following features
 
 1. Using data API to get the ticket requester's details


### PR DESCRIPTION
This pull request is based on the issue #58 

We've added screenshot for Freshdesk application in the v2 readme.

![Screenshot 2019-10-05 at 11 53 08 AM](https://user-images.githubusercontent.com/6701828/66250918-ba500e80-e766-11e9-85b4-4dac55adbc1a.png)
 
